### PR TITLE
Add a batch location update option

### DIFF
--- a/com.github.eclipse.projectlocationupdater/.classpath
+++ b/com.github.eclipse.projectlocationupdater/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.launching.macosx.MacOSXType/Java SE 6"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/com.github.eclipse.projectlocationupdater/plugin.xml
+++ b/com.github.eclipse.projectlocationupdater/plugin.xml
@@ -9,4 +9,21 @@
             id="com.github.eclipse.projectlocationupdater.properties.projectLocationUpdaterPropertyPage">
       </page>
    </extension>
+   <extension
+         point="org.eclipse.ui.popupMenus">
+      <objectContribution
+            adaptable="true"
+            id="com.github.eclipse.projectlocationupdater.batchUpdate"
+            nameFilter="*"
+            objectClass="org.eclipse.core.resources.IProject">
+         <action
+               class="com.github.eclipse.projectlocationupdater.actions.BatchUpdateAction"
+               enablesFor="*"
+               id="com.github.eclipse.projectlocationupdater.updateLocations"
+               label="Update Locations"
+               menubarPath="additions"
+               tooltip="Change project(s) location">
+         </action>
+      </objectContribution>
+   </extension>
 </plugin>

--- a/com.github.eclipse.projectlocationupdater/src/com/github/eclipse/projectlocationupdater/LocationUpdater.java
+++ b/com.github.eclipse.projectlocationupdater/src/com/github/eclipse/projectlocationupdater/LocationUpdater.java
@@ -1,8 +1,12 @@
 package com.github.eclipse.projectlocationupdater;
 
 import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.URI;
 
 import org.eclipse.core.internal.localstore.ILocalStoreConstants;
 import org.eclipse.core.resources.IProject;
@@ -39,7 +43,7 @@ public class LocationUpdater {
 	 *            Any project
 	 * @return An IPath to its .location file
 	 */
-	public IPath getProjectLocationFile(final IProject aProject) {
+	public IPath getProjectLocationFilePath(final IProject aProject) {
 
 		// Get the workspace root path
 		final IPath workspaceLocation = aProject.getWorkspace().getRoot()
@@ -100,5 +104,113 @@ public class LocationUpdater {
 	 */
 	private boolean systemIsWindows() {
 		return System.getProperty("os.name").toLowerCase().indexOf("windows") >= 0;
+	}
+
+	/**
+	 * Updates a substring of the location
+	 * 
+	 * @param aProject
+	 *            Project to be updated
+	 * @param aToReplace
+	 *            String part to be replaced
+	 * @param aReplacement
+	 *            Replacement string
+	 * @throws IOException
+	 *             Error reading or writing the project location file
+	 */
+	public void updateLocationSubstring(final IProject aProject,
+			final String aToReplace, final String aReplacement)
+			throws IOException {
+
+		// Read the current location
+		final IPath locationFilePath = getProjectLocationFilePath(aProject);
+		final String currentLocation = readProjectLocation(locationFilePath);
+
+		// Replace the substring
+		final String newLocation = currentLocation.replace(aToReplace,
+				aReplacement);
+
+		// Make a URI from the new path string
+		final URI newLocationURI = new Path(newLocation).toFile().toURI();
+
+		// Store the new location
+		writeProjectLocation(locationFilePath, newLocationURI);
+	}
+
+	/**
+	 * Writes the content of a project location file
+	 * 
+	 * @param aLocationFilePath
+	 *            Path to the project .location file
+	 * @param aLocationURI
+	 *            URI to the project itself
+	 * @throws FileNotFoundException .location
+	 *             file not found
+	 * @throws IOException
+	 *             Error reading or writing the location file
+	 */
+	public void writeProjectLocation(final IPath aLocationFilePath,
+			final URI aLocationURI) throws FileNotFoundException, IOException {
+
+		// Keep existing data
+		String[] referenceNames;
+
+		// Read the existing file
+		DataInputStream in = null;
+		try {
+			in = new DataInputStream(new FileInputStream(
+					aLocationFilePath.toFile()));
+
+			// Ignore the begin chunk
+			in.skipBytes(ILocalStoreConstants.BEGIN_CHUNK.length);
+
+			// Get the current project location
+			final String projectLocationStr = in.readUTF();
+			assert projectLocationStr.startsWith(URI_PREFIX);
+
+			// Store references
+			final int numRefs = in.readInt();
+			referenceNames = new String[numRefs];
+			for (int i = 0; i < numRefs; i++) {
+				referenceNames[i] = in.readUTF();
+			}
+
+			// Ignore the end chunk
+			in.skipBytes(ILocalStoreConstants.END_CHUNK.length);
+
+		} finally {
+			// Always close the file
+			if (in != null) {
+				in.close();
+			}
+		}
+
+		// Write the new content
+		DataOutputStream out = null;
+		try {
+			out = new DataOutputStream(new FileOutputStream(
+					aLocationFilePath.toFile()));
+
+			// Write the begin chunk
+			out.write(ILocalStoreConstants.BEGIN_CHUNK);
+
+			// Write the new location
+			out.writeUTF(URI_PREFIX + aLocationURI.toString());
+
+			// Write references
+			out.writeInt(referenceNames.length);
+			for (final String referenceName : referenceNames) {
+				out.writeUTF(referenceName);
+			}
+
+			// Write the end chunk
+			out.write(ILocalStoreConstants.END_CHUNK);
+			out.flush();
+
+		} finally {
+			if (out != null) {
+				out.close();
+			}
+		}
 	}
 }

--- a/com.github.eclipse.projectlocationupdater/src/com/github/eclipse/projectlocationupdater/LocationUpdater.java
+++ b/com.github.eclipse.projectlocationupdater/src/com/github/eclipse/projectlocationupdater/LocationUpdater.java
@@ -1,0 +1,104 @@
+package com.github.eclipse.projectlocationupdater;
+
+import java.io.DataInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import org.eclipse.core.internal.localstore.ILocalStoreConstants;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+
+/**
+ * Project location updater utility
+ * 
+ * "restriction" warnings are suppressed: we need do access Eclipse internal
+ * constants
+ * 
+ * @author Max Gensthaler
+ * @author Thomas Calmant
+ */
+@SuppressWarnings("restriction")
+public class LocationUpdater {
+
+	/** URI prefix and file protocol prefix */
+	private static final String FILE_URI_PREFIX = LocationUpdater.URI_PREFIX
+			+ "file:";
+
+	/** URI prefix in location file */
+	private static final String URI_PREFIX = "URI//";
+
+	/** Constant path to the workspace projects locations storage */
+	private static final IPath WORKSPACE_PROJECT_SETTINGS_RELPATH = new Path(
+			".metadata/.plugins/org.eclipse.core.resources/.projects");
+
+	/**
+	 * Retrieves the path to the .location file of a project in its workspace
+	 * 
+	 * @param aProject
+	 *            Any project
+	 * @return An IPath to its .location file
+	 */
+	public IPath getProjectLocationFile(final IProject aProject) {
+
+		// Get the workspace root path
+		final IPath workspaceLocation = aProject.getWorkspace().getRoot()
+				.getLocation();
+
+		// Forge the location file name
+		return workspaceLocation.append(WORKSPACE_PROJECT_SETTINGS_RELPATH)
+				.append(aProject.getName()).append(".location");
+	}
+
+	/**
+	 * Reads the content of a project location file
+	 * 
+	 * @param aLocationPath
+	 *            Path to a project location file
+	 * @return The value of the project location
+	 * @throws IOException
+	 *             Error reading the location file
+	 */
+	public String readProjectLocation(final IPath aLocationPath)
+			throws IOException {
+
+		DataInputStream in = null;
+		try {
+			// Read the location file
+			in = new DataInputStream(
+					new FileInputStream(aLocationPath.toFile()));
+
+			// Ignore the begin chunk
+			in.skipBytes(ILocalStoreConstants.BEGIN_CHUNK.length);
+
+			// Parse the location
+			String projectLocationStr = in.readUTF();
+			if (projectLocationStr.startsWith(FILE_URI_PREFIX)) {
+				projectLocationStr = projectLocationStr
+						.substring(FILE_URI_PREFIX.length());
+				if (systemIsWindows()
+						&& projectLocationStr.matches("^/[a-zA-Z]:")) {
+					// remove trailing "/" from absolute path on windows
+					projectLocationStr = projectLocationStr.substring(1);
+				}
+			}
+
+			return projectLocationStr;
+
+		} finally {
+			// Be nice
+			if (in != null) {
+				in.close();
+			}
+		}
+	}
+
+	/**
+	 * Checks if we're running on Windows
+	 * 
+	 * @return True if the OS name contains "windows"
+	 */
+	private boolean systemIsWindows() {
+		return System.getProperty("os.name").toLowerCase().indexOf("windows") >= 0;
+	}
+}

--- a/com.github.eclipse.projectlocationupdater/src/com/github/eclipse/projectlocationupdater/LocationUpdater.java
+++ b/com.github.eclipse.projectlocationupdater/src/com/github/eclipse/projectlocationupdater/LocationUpdater.java
@@ -126,15 +126,15 @@ public class LocationUpdater {
 	 * 
 	 * @param aProject
 	 *            Project to be updated
-	 * @param aToReplace
-	 *            String part to be replaced
-	 * @param aReplacement
-	 *            Replacement string
+	 * @param aPreviousPrefix
+	 *            Prefix path to be replaced
+	 * @param aNewPrefix
+	 *            Replacement path
 	 * @throws IOException
 	 *             Error reading or writing the project location file
 	 */
 	public void updateLocationSubstring(final IProject aProject,
-			final String aToReplace, final String aReplacement)
+			final String aPreviousPrefix, final String aNewPrefix)
 			throws IOException {
 
 		// Read the current location
@@ -142,8 +142,8 @@ public class LocationUpdater {
 		final String currentLocation = readProjectLocation(locationFilePath);
 
 		// Replace the substring
-		final String newLocation = currentLocation.replace(aToReplace,
-				aReplacement);
+		final String newLocation = currentLocation.replace(aPreviousPrefix,
+				aNewPrefix);
 
 		// Make a URI from the new path string
 		final URI newLocationURI = new Path(newLocation).toFile().toURI();

--- a/com.github.eclipse.projectlocationupdater/src/com/github/eclipse/projectlocationupdater/LocationUpdater.java
+++ b/com.github.eclipse.projectlocationupdater/src/com/github/eclipse/projectlocationupdater/LocationUpdater.java
@@ -98,6 +98,21 @@ public class LocationUpdater {
 	}
 
 	/**
+	 * Reads the content of a project location file
+	 * 
+	 * @param aProject
+	 *            Project to locate
+	 * @return The value of the project location
+	 * @throws IOException
+	 *             Error reading the location file
+	 */
+	public String readProjectLocation(final IProject aProject)
+			throws IOException {
+
+		return readProjectLocation(getProjectLocationFilePath(aProject));
+	}
+
+	/**
 	 * Checks if we're running on Windows
 	 * 
 	 * @return True if the OS name contains "windows"

--- a/com.github.eclipse.projectlocationupdater/src/com/github/eclipse/projectlocationupdater/actions/BatchUpdateAction.java
+++ b/com.github.eclipse.projectlocationupdater/src/com/github/eclipse/projectlocationupdater/actions/BatchUpdateAction.java
@@ -1,0 +1,126 @@
+package com.github.eclipse.projectlocationupdater.actions;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.window.Window;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IObjectActionDelegate;
+import org.eclipse.ui.IWorkbenchPart;
+
+import com.github.eclipse.projectlocationupdater.Activator;
+import com.github.eclipse.projectlocationupdater.LocationUpdater;
+
+/**
+ * Action associated to the "Update Location" pop-up menu
+ * 
+ * @author Thomas Calmant
+ */
+public class BatchUpdateAction implements IObjectActionDelegate {
+
+	/** Current selection */
+	private ISelection pSelection;
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.ui.IActionDelegate#run(org.eclipse.jface.action.IAction)
+	 */
+	@Override
+	public void run(final IAction aAction) {
+
+		// Prepare selection list
+		final Set<IProject> selectedProjects = new LinkedHashSet<IProject>();
+		if (pSelection instanceof IStructuredSelection) {
+			for (final Iterator<?> it = ((IStructuredSelection) pSelection)
+					.iterator(); it.hasNext();) {
+
+				final Object element = it.next();
+				IProject project = null;
+
+				if (element instanceof IProject) {
+					// Is the element a project ?
+					project = (IProject) element;
+
+				} else if (element instanceof IAdaptable) {
+					// Is the element adaptable to a project ?
+					project = (IProject) ((IAdaptable) element)
+							.getAdapter(IProject.class);
+				}
+
+				if (project != null && !project.isOpen()) {
+					// Add the found project, if it is closed
+					selectedProjects.add(project);
+				}
+			}
+		}
+
+		if (selectedProjects.isEmpty()) {
+			// No valid project found, do nothing
+			return;
+		}
+
+		// Get the shell
+		final Shell shell = Activator.getDefault().getWorkbench()
+				.getActiveWorkbenchWindow().getShell();
+
+		final LocationUpdateDialog dialog = new LocationUpdateDialog(shell,
+				selectedProjects);
+		if (dialog.open() != Window.OK) {
+			// User click CANCEL: do nothing
+			return;
+		}
+
+		// Get the common part and the new path
+		final String[] results = dialog.getPathModification();
+		final String commonPart = results[0];
+		final String newPath = results[1];
+
+		// Update project
+		final LocationUpdater updater = new LocationUpdater();
+		for (final IProject project : selectedProjects) {
+			try {
+				updater.updateLocationSubstring(project, commonPart, newPath);
+
+			} catch (final IOException ex) {
+				// TODO Use a logger
+				System.err.println("Error updating the location file: " + ex);
+				ex.printStackTrace();
+			}
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * org.eclipse.ui.IActionDelegate#selectionChanged(org.eclipse.jface.action
+	 * .IAction, org.eclipse.jface.viewers.ISelection)
+	 */
+	@Override
+	public void selectionChanged(final IAction aAction,
+			final ISelection aSelection) {
+
+		pSelection = aSelection;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * org.eclipse.ui.IObjectActionDelegate#setActivePart(org.eclipse.jface.
+	 * action.IAction, org.eclipse.ui.IWorkbenchPart)
+	 */
+	@Override
+	public void setActivePart(final IAction aAction,
+			final IWorkbenchPart aTargetPart) {
+		// Nothing to do
+	}
+}

--- a/com.github.eclipse.projectlocationupdater/src/com/github/eclipse/projectlocationupdater/actions/LocationUpdateDialog.java
+++ b/com.github.eclipse.projectlocationupdater/src/com/github/eclipse/projectlocationupdater/actions/LocationUpdateDialog.java
@@ -1,17 +1,22 @@
 package com.github.eclipse.projectlocationupdater.actions;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
-import java.util.List;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.dialogs.TitleAreaDialog;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.DirectoryDialog;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.List;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 
@@ -29,7 +34,10 @@ public class LocationUpdateDialog extends TitleAreaDialog {
 	private Text pNewPathText;
 
 	/** The modified project */
-	private final List<IProject> pProjects;
+	private final Collection<IProject> pProjects;
+
+	/** Workspace root path */
+	private final String pWorkspaceRoot;
 
 	/**
 	 * Instantiate a new location update dialog
@@ -41,13 +49,124 @@ public class LocationUpdateDialog extends TitleAreaDialog {
 	 */
 	public LocationUpdateDialog(final Shell aParentShell,
 			final Collection<IProject> aProjects) {
+
 		super(aParentShell);
+
+		// Get the workspace root
+		pWorkspaceRoot = aProjects.iterator().next().getWorkspace().getRoot()
+				.getLocation().toString();
 
 		// Copy the projects list
 		pProjects = new LinkedList<IProject>(aProjects);
 
 		// TODO: Compute the common path part
 		pCommonPath = "toto";
+	}
+
+	/**
+	 * Shows the common part of the project locations
+	 * 
+	 * @param aComposite
+	 *            Parent composite
+	 */
+	private void addCommonLocation(final Composite aComposite) {
+
+		final Label currentLocationLabel = new Label(aComposite, SWT.NONE);
+		currentLocationLabel.setText("Common part of locations:");
+
+		final Text currentLocationText = new Text(aComposite, SWT.SINGLE
+				| SWT.READ_ONLY | SWT.BORDER);
+		final GridData gd = new GridData(SWT.FILL, SWT.FILL, true, false, 2, 1);
+		gd.widthHint = 40;
+		currentLocationText.setLayoutData(gd);
+		currentLocationText.setText(pCommonPath);
+	}
+
+	/**
+	 * Lets the user enter the new path
+	 * 
+	 * @param aComposite
+	 *            Parent composite
+	 */
+	private void addNewLocation(final Composite aComposite) {
+		final Label newLocationLabel = new Label(aComposite, SWT.NONE);
+		newLocationLabel.setText("New location:");
+
+		pNewPathText = new Text(aComposite, SWT.SINGLE | SWT.BORDER);
+		final GridData gd = new GridData(SWT.FILL, SWT.CENTER, true, false, 1,
+				1);
+		gd.widthHint = 40;
+		pNewPathText.setLayoutData(gd);
+		pNewPathText.setText(pCommonPath);
+
+		final Button browseButton = new Button(aComposite, SWT.NONE);
+		browseButton.setText("...");
+		browseButton.addSelectionListener(new SelectionListener() {
+			@Override
+			public void widgetDefaultSelected(final SelectionEvent e) {
+				// Do nothing
+			}
+
+			@Override
+			public void widgetSelected(final SelectionEvent e) {
+				final DirectoryDialog dd = new DirectoryDialog(aComposite
+						.getShell(), SWT.OPEN);
+				dd.setFilterPath(pWorkspaceRoot);
+				final String selected = dd.open();
+				pNewPathText.setText(selected);
+			}
+		});
+	}
+
+	/**
+	 * Shows the list of selected projects
+	 * 
+	 * @param aComposite
+	 *            Parent composite
+	 */
+	private void addProjectsList(final Composite aComposite) {
+
+		// Make an array of projects names
+		int i = 0;
+		final String[] projectNames = new String[pProjects.size()];
+		for (final IProject project : pProjects) {
+			projectNames[i++] = project.getName();
+		}
+
+		// Sort it
+		Arrays.sort(projectNames);
+
+		// Make the list widget
+		final List projectsList = new List(aComposite, SWT.V_SCROLL);
+		for (final String projectName : projectNames) {
+			projectsList.add(projectName);
+		}
+
+		// Let it have some space
+		final GridData gridData = new GridData(SWT.FILL, SWT.FILL, true, true);
+		gridData.horizontalSpan = 3;
+		projectsList.setLayoutData(gridData);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * org.eclipse.jface.dialogs.TitleAreaDialog#createContents(org.eclipse.
+	 * swt.widgets.Composite)
+	 */
+	@Override
+	protected Control createContents(final Composite aParent) {
+
+		// Call parent
+		final Control content = super.createContents(aParent);
+
+		// Set the title
+		setTitle("Project location updater");
+
+		// Set the message
+		setMessage("Update the location of " + pProjects.size() + " project(s)");
+		return content;
 	}
 
 	/*
@@ -61,38 +180,22 @@ public class LocationUpdateDialog extends TitleAreaDialog {
 	protected Control createDialogArea(final Composite aParent) {
 
 		// Call parent
-		final Composite composite = (Composite) super.createDialogArea(aParent);
+		final Composite dialogArea = (Composite) super
+				.createDialogArea(aParent);
 
 		// Prepare the layout
-		final GridLayout layout = new GridLayout(1, false);
-		composite.setLayout(layout);
+		final Composite composite = new Composite(dialogArea, SWT.NONE);
+		composite.setLayoutData(new GridData(GridData.FILL_BOTH));
+		composite.setLayout(new GridLayout(3, false));
 
-		final GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
-
-		// TODO: enhance the UI
-
-		// TODO: show the list of the modified projects
+		// Show the list of the modified projects
+		addProjectsList(composite);
 
 		// Current path
-		final Label currentPathLabel = new Label(aParent, SWT.NONE);
-		currentPathLabel.setLayoutData(gridData);
-		currentPathLabel.setText("Current path:");
-
-		final Label currentPathText = new Label(aParent, SWT.BORDER);
-		currentPathText.setLayoutData(gridData);
-		currentPathText.setText(pCommonPath);
+		addCommonLocation(composite);
 
 		// New path
-		final Label newPathLabel = new Label(aParent, SWT.NONE);
-		newPathLabel.setLayoutData(gridData);
-		newPathLabel.setText("New path:");
-
-		pNewPathText = new Text(aParent, SWT.BORDER);
-		pNewPathText.setLayoutData(gridData);
-		pNewPathText.setText(pCommonPath);
-
-		// TODO: add folder selection buttons
-
+		addNewLocation(composite);
 		return composite;
 	}
 

--- a/com.github.eclipse.projectlocationupdater/src/com/github/eclipse/projectlocationupdater/actions/LocationUpdateDialog.java
+++ b/com.github.eclipse.projectlocationupdater/src/com/github/eclipse/projectlocationupdater/actions/LocationUpdateDialog.java
@@ -48,7 +48,7 @@ public class LocationUpdateDialog extends TitleAreaDialog {
 	 *            Projects that will be configured
 	 */
 	public LocationUpdateDialog(final Shell aParentShell,
-			final Collection<IProject> aProjects) {
+			final Collection<IProject> aProjects, final String aCommonPath) {
 
 		super(aParentShell);
 
@@ -58,9 +58,7 @@ public class LocationUpdateDialog extends TitleAreaDialog {
 
 		// Copy the projects list
 		pProjects = new LinkedList<IProject>(aProjects);
-
-		// TODO: Compute the common path part
-		pCommonPath = "toto";
+		pCommonPath = aCommonPath;
 	}
 
 	/**
@@ -200,13 +198,11 @@ public class LocationUpdateDialog extends TitleAreaDialog {
 	}
 
 	/**
-	 * Returns a couple of Strings: the common part of the current path to be
-	 * replaced and its replacement
+	 * Returns the new location chosen by the user
 	 * 
-	 * @return A 2-elements array
+	 * @return The new location
 	 */
-	public String[] getPathModification() {
-
-		return new String[] { pCommonPath, pNewPathText.getText() };
+	public String getNewLocation() {
+		return pNewPathText.getText();
 	}
 }

--- a/com.github.eclipse.projectlocationupdater/src/com/github/eclipse/projectlocationupdater/actions/LocationUpdateDialog.java
+++ b/com.github.eclipse.projectlocationupdater/src/com/github/eclipse/projectlocationupdater/actions/LocationUpdateDialog.java
@@ -30,7 +30,10 @@ public class LocationUpdateDialog extends TitleAreaDialog {
 	/** Current common path part (read only) */
 	private final String pCommonPath;
 
-	/** New common path part */
+	/** New common path value */
+	private String pNewPathString;
+
+	/** New common path text field */
 	private Text pNewPathText;
 
 	/** The modified project */
@@ -51,6 +54,7 @@ public class LocationUpdateDialog extends TitleAreaDialog {
 			final Collection<IProject> aProjects, final String aCommonPath) {
 
 		super(aParentShell);
+		setShellStyle(getShellStyle() | SWT.RESIZE);
 
 		// Get the workspace root
 		pWorkspaceRoot = aProjects.iterator().next().getWorkspace().getRoot()
@@ -111,7 +115,9 @@ public class LocationUpdateDialog extends TitleAreaDialog {
 						.getShell(), SWT.OPEN);
 				dd.setFilterPath(pWorkspaceRoot);
 				final String selected = dd.open();
-				pNewPathText.setText(selected);
+				if (selected != null) {
+					pNewPathText.setText(selected);
+				}
 			}
 		});
 	}
@@ -194,7 +200,7 @@ public class LocationUpdateDialog extends TitleAreaDialog {
 
 		// New path
 		addNewLocation(composite);
-		return composite;
+		return dialogArea;
 	}
 
 	/**
@@ -203,6 +209,14 @@ public class LocationUpdateDialog extends TitleAreaDialog {
 	 * @return The new location
 	 */
 	public String getNewLocation() {
-		return pNewPathText.getText();
+		return pNewPathString;
+	}
+
+	@Override
+	protected void okPressed() {
+
+		// Store the field content, while it is not disposed
+		pNewPathString = pNewPathText.getText();
+		super.okPressed();
 	}
 }

--- a/com.github.eclipse.projectlocationupdater/src/com/github/eclipse/projectlocationupdater/actions/LocationUpdateDialog.java
+++ b/com.github.eclipse.projectlocationupdater/src/com/github/eclipse/projectlocationupdater/actions/LocationUpdateDialog.java
@@ -1,0 +1,109 @@
+package com.github.eclipse.projectlocationupdater.actions;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jface.dialogs.TitleAreaDialog;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+
+/**
+ * Requests the new location to the user
+ * 
+ * @author Thomas Calmant
+ */
+public class LocationUpdateDialog extends TitleAreaDialog {
+
+	/** Current common path part (read only) */
+	private final String pCommonPath;
+
+	/** New common path part */
+	private Text pNewPathText;
+
+	/** The modified project */
+	private final List<IProject> pProjects;
+
+	/**
+	 * Instantiate a new location update dialog
+	 * 
+	 * @param aParentShell
+	 *            The parent shell
+	 * @param aProjects
+	 *            Projects that will be configured
+	 */
+	public LocationUpdateDialog(final Shell aParentShell,
+			final Collection<IProject> aProjects) {
+		super(aParentShell);
+
+		// Copy the projects list
+		pProjects = new LinkedList<IProject>(aProjects);
+
+		// TODO: Compute the common path part
+		pCommonPath = "toto";
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * org.eclipse.jface.dialogs.TitleAreaDialog#createDialogArea(org.eclipse
+	 * .swt.widgets.Composite)
+	 */
+	@Override
+	protected Control createDialogArea(final Composite aParent) {
+
+		// Call parent
+		final Composite composite = (Composite) super.createDialogArea(aParent);
+
+		// Prepare the layout
+		final GridLayout layout = new GridLayout(1, false);
+		composite.setLayout(layout);
+
+		final GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
+
+		// TODO: enhance the UI
+
+		// TODO: show the list of the modified projects
+
+		// Current path
+		final Label currentPathLabel = new Label(aParent, SWT.NONE);
+		currentPathLabel.setLayoutData(gridData);
+		currentPathLabel.setText("Current path:");
+
+		final Label currentPathText = new Label(aParent, SWT.BORDER);
+		currentPathText.setLayoutData(gridData);
+		currentPathText.setText(pCommonPath);
+
+		// New path
+		final Label newPathLabel = new Label(aParent, SWT.NONE);
+		newPathLabel.setLayoutData(gridData);
+		newPathLabel.setText("New path:");
+
+		pNewPathText = new Text(aParent, SWT.BORDER);
+		pNewPathText.setLayoutData(gridData);
+		pNewPathText.setText(pCommonPath);
+
+		// TODO: add folder selection buttons
+
+		return composite;
+	}
+
+	/**
+	 * Returns a couple of Strings: the common part of the current path to be
+	 * replaced and its replacement
+	 * 
+	 * @return A 2-elements array
+	 */
+	public String[] getPathModification() {
+
+		return new String[] { pCommonPath, pNewPathText.getText() };
+	}
+}


### PR DESCRIPTION
As requested in issue #2, those commits add an "Update Locations" options in the pop menu of the projects explorer.
It filters the selected projects: only the closed ones can be updated.
The update is done on the common prefix of the location URI:
- if a project in the selection has a different location (like /opt/git and /var/git), the update will be refused
- If you have 2 projects /var/git/project1 and /var/git/sub/project2, you can replace the /var/git/ part by a new one, say /var/gitolite. The results will be /var/gitolite/project1 and /var/gitolite/sub/project2.

Finally, a LocationUpdater utility class has been created to centralize the location update process.
Although, I didn't updated the PropertyPage code to use this new class.

This version lacks logging and some dialogs to notify the user of the operations/errors.
It also lacks internationalization methods.
